### PR TITLE
Remove automatic screenshots on test failure

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -28,7 +28,7 @@ jobs:
         uses: getgauge/setup-gauge@master
         with:
           gauge-version: master
-          gauge-plugins: python, html-report, screenshot
+          gauge-plugins: python, html-report
 
       - name: FTs
         run: gauge run specs

--- a/env/default/default.properties
+++ b/env/default/default.properties
@@ -10,7 +10,7 @@ gauge_reports_dir = reports
 overwrite_reports = true
 
 # Set to false to disable screenshots on failure in reports.
-screenshot_on_failure = true
+screenshot_on_failure = false
 
 # The path to the gauge logs directory. Should be either relative to the project directory or an absolute path
 logs_directory = logs


### PR DESCRIPTION
We are not testing a web application, so screenshots are not applicable.