### PR TITLE
Fix Gauge report artifact storage to always happen

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Upload Gauge specs html report
         uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: gauge-html-report
           path: reports/html-report/


### PR DESCRIPTION
Prior to this commit the Gauge html report was only being stored as a
GitHub Actions artifact if the tests passed.