### PR TITLE
Install screenshot plugin on devcontainer

### DIFF
--- a/.devcontainer/scripts/install-gauge.sh
+++ b/.devcontainer/scripts/install-gauge.sh
@@ -6,5 +6,6 @@ TRUNCATED_GAUGE_VERSION="${GAUGE_VERSION:1}"
 wget https://github.com/getgauge/gauge/releases/download/$GAUGE_VERSION/gauge-$TRUNCATED_GAUGE_VERSION-linux.x86_64.zip
 unzip -o gauge-$TRUNCATED_GAUGE_VERSION-linux.x86_64.zip -d /usr/local/bin
 su codespace -c "gauge install html-report"
+su codespace -c "gauge install screenshot"
 su codespace -c "gauge install python"
 # add more plugins here as required


### PR DESCRIPTION
Gauge will automatically install the screenshot plugin when first
running specs, if it is not already installed - even if we have disabled
the screenshot capturing in our config.  So we are best off installing
it on the devcontainer, to speed up the first spec run.