### PR TITLE
Use the Python image on the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,9 @@
-FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
 
-COPY scripts/* /tmp/scripts/
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT=3
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
+
+COPY .devcontainer/scripts/* /tmp/scripts/
 
 USER root
 
@@ -8,4 +11,4 @@ RUN /tmp/scripts/install-hadolint.sh \
     && /tmp/scripts/install-gauge.sh \
     && rm -rf /tmp/scripts
 
-USER codespace
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,5 +69,5 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// "oryx build" will automatically install your dependencies and attempt to build your project
-	"postCreateCommand": "oryx build -p virtualenv_name=.venv || echo 'Could not auto-build. Skipping.'"
+	"postCreateCommand": "pip install -r requirements.txt "
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,15 @@
 {
-	"name": "GitHub Codespaces (Default)",
+	"name": "Python 3",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": {
+			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
+			"VARIANT": "3.8",
+			// Options
+			"INSTALL_NODE": "false",
+			"NODE_VERSION": "lts/*"
+		}
 	},
 	"settings": {
 		"editor.formatOnSave": true,
@@ -43,17 +51,6 @@
 		"files.autoSave": "afterDelay",
 		"files.autoSaveDelay": 500,
 	},
-	"remoteUser": "codespace",
-	"overrideCommand": false,
-	"workspaceMount": "source=${localWorkspaceFolder},target=/home/codespace/workspace,type=bind,consistency=cached",
-	"workspaceFolder": "/home/codespace/workspace",
-	"runArgs": [
-		"--cap-add=SYS_PTRACE",
-		"--security-opt",
-		"seccomp=unconfined",
-		"--privileged",
-		"--init"
-	],
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"GitHub.vscode-pull-request-github",
@@ -69,5 +66,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// "oryx build" will automatically install your dependencies and attempt to build your project
-	"postCreateCommand": "pip install -r requirements.txt "
+	"postCreateCommand": "pip install -r requirements.txt",
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
 }

--- a/.devcontainer/scripts/install-gauge.sh
+++ b/.devcontainer/scripts/install-gauge.sh
@@ -5,7 +5,7 @@ TRUNCATED_GAUGE_VERSION="${GAUGE_VERSION:1}"
 
 wget https://github.com/getgauge/gauge/releases/download/$GAUGE_VERSION/gauge-$TRUNCATED_GAUGE_VERSION-linux.x86_64.zip
 unzip -o gauge-$TRUNCATED_GAUGE_VERSION-linux.x86_64.zip -d /usr/local/bin
-su codespace -c "gauge install html-report"
-su codespace -c "gauge install screenshot"
-su codespace -c "gauge install python"
+su vscode -c "gauge install html-report"
+su vscode -c "gauge install screenshot"
+su vscode -c "gauge install python"
 # add more plugins here as required


### PR DESCRIPTION
The [universal Codespaces image][1] was causing difficulties with there
being multiple versions of Python installed. Much simpler to use the
[Python image][2]
    
[1]: https://github.com/microsoft/vscode-dev-containers/tree/master/containers/codespaces-linux
[2]: https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3