### PR TITLE
Fix Python path on devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 		"go.lintFlags": [
 			"--fast"
 		],
-		"python.pythonPath": "/opt/python/latest/bin/python",
+		"python.pythonPath": "/usr/local/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.formatting.provider": "black",


### PR DESCRIPTION
This should have been done in #14, but was missed.