### PR TITLE
Ensure Gauge secrets are ignored by source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ reports
 # Gauge - python compiled files
 *.pyc
 
+# Gauge - secrets
+secrets.properties
+# ignore the singular too, just in case someone uses it as the file name
+secret.properties
+
 
 # Created by https://www.gitignore.io/api/visualstudiocode
 # Edit at https://www.gitignore.io/?templates=visualstudiocode


### PR DESCRIPTION
By convention we will allow Gauge secrets to be stored in a [Gauge
properties file][1] called `secrets.properties`.  Secrets must never be
stored in source control, so this commit ensures that any files with
that name are ignored by Git.

NB Our Gauge secrets don't have to be stored in a properties file - they
can also be [set as environment variables][2].

[1]: https://docs.gauge.org/configuration.html
[2]: https://docs.gauge.org/configuration.html#precedence-of-environments-when-running-gauge